### PR TITLE
fix build error.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,7 @@ export class AppComponent {
     remote.dialog.showMessageBox(options);
   }
   openOpenDialog(){
-    remote.dialog.showOpenDialog([]);
+    remote.dialog.showOpenDialog({});
   }
 
   changeSample(e: any) {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "noStrictGenericChecks": true,  
     "lib": ["es6", "dom"],
     "mapRoot": "./",
     "module": "es6",


### PR DESCRIPTION
errors occured in `npm install`.

```
ERROR in /ng2-electron-builder/node_modules/rxjs/Subject.d.ts (16,22): Class 'Subject<T>' incorrectly extends base class 'Observable<T>'.
  Types of property 'lift' are incompatible.
    Type '<R>(operator: Operator<T, R>) => Observable<T>' is not assignable to type '<R>(operator: Operator<T, R>) => Observable<R>'.
      Type 'Observable<T>' is not assignable to type 'Observable<R>'.
        Type 'T' is not assignable to type 'R'.

ERROR in /ng2-electron-builder/src/app/app.component.ts (33,34): Type 'undefined[]' has no properties in common with type 'OpenDialogOptions'.
```

First error is electron problem.
https://github.com/ReactiveX/rxjs/issues/2539
So, I add noStrictGenericChecks in tsconfig.

Second error is argument mistake of electron api.
https://github.com/electron/electron/blob/master/docs/api/dialog.md#dialogshowopendialogbrowserwindow-options-callback


